### PR TITLE
Some clip fixes

### DIFF
--- a/limit-break/clip.cpp
+++ b/limit-break/clip.cpp
@@ -53,7 +53,7 @@ static void set_clip(float r, ClipType type)
 	clip_current = clip_limit;
 }
 
-signed int __cdecl ClipObject_r(ObjectMaster *a1, float dist)
+signed int __cdecl ClipObject_orig(ObjectMaster *a1, float dist)
 {
 	SETObjData *SetData = a1->SETData.SETData;;
 	
@@ -66,9 +66,7 @@ signed int __cdecl ClipObject_r(ObjectMaster *a1, float dist)
 
 	if ((Camera_Data1 && ObjectInRange(&Camera_Data1->Position, pos->x, pos->y, pos->z, dist))
 		|| (EntityData1Ptrs[0] && ObjectInRange(&EntityData1Ptrs[0]->Position, pos->x, pos->y, pos->z, dist))
-		|| (EntityData1Ptrs[1]
-		&& !LOBYTE(EntityData1Ptrs[1]->CharIndex)
-		&& ObjectInRange(&EntityData1Ptrs[1]->Position, pos->x, pos->y, pos->z, 1600.0)))
+		|| (EntityData1Ptrs[1] && !LOBYTE(EntityData1Ptrs[1]->CharIndex) && ObjectInRange(&EntityData1Ptrs[1]->Position, pos->x, pos->y, pos->z, 1600.0)))
 	{
 		return 0;
 	}
@@ -88,15 +86,15 @@ static int __cdecl ClipSetObject_r(ObjectMaster* a1)
 
 	if (!(ControllerPointers[0]->HeldButtons & Buttons_Z))
 	{
-		return ClipObject_r(a1, set != nullptr ? max(clip_current, set->Distance) : clip_current);
+		return ClipObject_orig(a1, set != nullptr ? max(clip_current, set->Distance) : clip_current);
 	}
 
 	if (set)
 	{
-		return ClipObject_r(a1, set->Distance);
+		return ClipObject_orig(a1, set->Distance);
 	}
 
-	return ClipObject_r(a1, clip_default);
+	return ClipObject_orig(a1, clip_default);
 }
 
 // ReSharper disable once CppDeclaratorNeverUsed

--- a/limit-break/clip.cpp
+++ b/limit-break/clip.cpp
@@ -53,6 +53,30 @@ static void set_clip(float r, ClipType type)
 	clip_current = clip_limit;
 }
 
+signed int __cdecl ClipObject_r(ObjectMaster *a1, float dist)
+{
+	SETObjData *SetData = a1->SETData.SETData;;
+	
+	if (SetData && SetData->Flags & 8 || dist == 0.0)
+	{
+		return 0;
+	}
+
+	NJS_VECTOR *pos = &a1->Data1->Position;
+
+	if ((Camera_Data1 && ObjectInRange(&Camera_Data1->Position, pos->x, pos->y, pos->z, dist))
+		|| (EntityData1Ptrs[0] && ObjectInRange(&EntityData1Ptrs[0]->Position, pos->x, pos->y, pos->z, dist))
+		|| (EntityData1Ptrs[1]
+		&& !LOBYTE(EntityData1Ptrs[1]->CharIndex)
+		&& ObjectInRange(&EntityData1Ptrs[1]->Position, pos->x, pos->y, pos->z, 1600.0)))
+	{
+		return 0;
+	}
+
+	a1->MainSub = DeleteObjectMaster;
+	return 1;
+}
+
 static int __cdecl ClipSetObject_r(ObjectMaster* a1)
 {
 	auto set = a1->SETData.SETData;
@@ -64,15 +88,15 @@ static int __cdecl ClipSetObject_r(ObjectMaster* a1)
 
 	if (!(ControllerPointers[0]->HeldButtons & Buttons_Z))
 	{
-		return ClipObject(a1, set != nullptr ? max(clip_current, set->Distance) : clip_current);
+		return ClipObject_r(a1, set != nullptr ? max(clip_current, set->Distance) : clip_current);
 	}
 
 	if (set)
 	{
-		return ClipObject(a1, set->Distance);
+		return ClipObject_r(a1, set->Distance);
 	}
 
-	return ClipObject(a1, clip_default);
+	return ClipObject_r(a1, clip_default);
 }
 
 // ReSharper disable once CppDeclaratorNeverUsed
@@ -104,6 +128,7 @@ void clip_init()
 {
 	WriteJump(ClipSetObject, ClipSetObject_r);
 	WriteJump(ClipSetObject_Min, ClipSetObject_r);
+	WriteJump(ClipObject, ClipSetObject_r);
 	WriteCall((void*)0x0046BBB9, ObjectInRange_asm);
 	WriteData((float**)0x0046B6F8, &clip_current);
 	WriteData((float**)0x0046B713, &clip_current);

--- a/limit-break/limit-break.vcxproj
+++ b/limit-break/limit-break.vcxproj
@@ -88,6 +88,7 @@
     <ClInclude Include="clip.h" />
     <ClInclude Include="collision.h" />
     <ClInclude Include="misc.h" />
+    <ClInclude Include="objdef.h" />
     <ClInclude Include="object.h" />
     <ClInclude Include="set.h" />
     <ClInclude Include="stdafx.h" />
@@ -98,6 +99,7 @@
     <ClCompile Include="clip.cpp" />
     <ClCompile Include="collision.cpp" />
     <ClCompile Include="mod.cpp" />
+    <ClCompile Include="objdef.cpp" />
     <ClCompile Include="object.cpp" />
     <ClCompile Include="set.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/limit-break/limit-break.vcxproj.filters
+++ b/limit-break/limit-break.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClInclude Include="..\sadx-mod-loader\libmodutils\Trampoline.h">
       <Filter>Header Files\external</Filter>
     </ClInclude>
+    <ClInclude Include="objdef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -70,6 +73,9 @@
     </ClCompile>
     <ClCompile Include="..\sadx-mod-loader\libmodutils\Trampoline.cpp">
       <Filter>Source Files\external</Filter>
+    </ClCompile>
+    <ClCompile Include="objdef.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/limit-break/mod.cpp
+++ b/limit-break/mod.cpp
@@ -62,7 +62,9 @@ extern "C"
 
 	__declspec(dllexport) void __cdecl OnFrame()
 	{
+#ifdef _DEBUG
 		DisplayDebugStringFormatted(NJM_LOCATION(1, 5), "CLIP: %f", clip_current);
+#endif
 		object_OnFrame();
 		textures_OnFrame();
 	}

--- a/limit-break/mod.cpp
+++ b/limit-break/mod.cpp
@@ -58,6 +58,7 @@ extern "C"
 		clip_init();
 		textures_init();
 		set_init();
+		objdef_init();
 	}
 
 	__declspec(dllexport) void __cdecl OnFrame()

--- a/limit-break/objdef.cpp
+++ b/limit-break/objdef.cpp
@@ -8,13 +8,20 @@ void Ring_Main_r(ObjectMaster *a1) {
 	Ring_Main(a1);
 }
 
+float __stdcall squareroot_r(float a1) {
+	return 0;
+}
+
 void objdef_init() {
 	float range = 3600000;
 
 	//Bridge in EC01
 	WriteData((float*)0x7EC9F8, range);
 	WriteData((float*)0x7EC9F4, range);
-
+	
+	//Hovering helicopters
+	WriteCall((void**)0x6137E8, squareroot_r);
+	
 	//SkyDeck ring hack
 	WriteData((ObjectFuncPtr*)0x2230F2C, Ring_Main_r);
 }

--- a/limit-break/objdef.cpp
+++ b/limit-break/objdef.cpp
@@ -1,10 +1,20 @@
 #include "stdafx.h"
 #include "objdef.h"
 
+void Ring_Main_r(ObjectMaster *a1) {
+	if (a1->Data1->Scale.x == -1)
+		a1->Data1->Scale.x = 4;
+
+	Ring_Main(a1);
+}
+
 void objdef_init() {
 	float range = 3600000;
 
 	//Bridge in EC01
 	WriteData((float*)0x7EC9F8, range);
 	WriteData((float*)0x7EC9F4, range);
+
+	//SkyDeck ring hack
+	WriteData((ObjectFuncPtr*)0x2230F2C, Ring_Main_r);
 }

--- a/limit-break/objdef.cpp
+++ b/limit-break/objdef.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "objdef.h"
 
-void Ring_Main_r(ObjectMaster *a1) {
+void Ring_Main_SkyDeck(ObjectMaster *a1) {
 	if (a1->Data1->Scale.x == -1)
 		a1->Data1->Scale.x = 4;
 
@@ -23,5 +23,5 @@ void objdef_init() {
 	WriteCall((void**)0x6137E8, squareroot_r);
 	
 	//SkyDeck ring hack
-	WriteData((ObjectFuncPtr*)0x2230F2C, Ring_Main_r);
+	WriteData((ObjectFuncPtr*)0x2230F2C, Ring_Main_SkyDeck);
 }

--- a/limit-break/objdef.cpp
+++ b/limit-break/objdef.cpp
@@ -1,0 +1,10 @@
+#include "stdafx.h"
+#include "objdef.h"
+
+void objdef_init() {
+	float range = 3600000;
+
+	//Bridge in EC01
+	WriteData((float*)0x7EC9F8, range);
+	WriteData((float*)0x7EC9F4, range);
+}

--- a/limit-break/objdef.h
+++ b/limit-break/objdef.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void objdef_init();

--- a/limit-break/set.cpp
+++ b/limit-break/set.cpp
@@ -38,5 +38,8 @@ void set_init()
 	WriteData((int*)0x0046BF3D, SET_COUNT);
 	WriteData((int*)0x0046BF44, SET_COUNT);
 
+	WriteData((short**)0x0046C1DB, &set_table[SET_COUNT].Flags);
+	WriteData((int*)0x0046C1E0, (SET_COUNT + 1));
+
 	WriteData((int*)0x00591A32, MISSION_SET_COUNT);
 }

--- a/limit-break/stdafx.h
+++ b/limit-break/stdafx.h
@@ -11,3 +11,4 @@
 #include "collision.h"
 #include "textures.h"
 #include "set.h"
+#include "objdef.h"


### PR DESCRIPTION
This is a series of fixes that:
- Reset the SETTable properly (itemboxes, checkpoints...)
- Break the limit of all objects using ClipObject directly
- Fix some hard-coded clip (Emerald Coast floating bridge, Speed Highway helicopter)
- Fix Sky Deck rings at the beginning

After testing, it fixes the following issues: #3, #7, #9.

The code is bad though, so feel free to change it.